### PR TITLE
Rename `parallel_for` to `parallel_exec`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,12 @@ read-buffer: func(buffer: buffer) -> expected<list<u8>, error>
 There must be a way to indicate what code should be run in parallel. Several
 other designs were discarded to reach the current mechanism: a binary-encoded
 WebAssembly module that exports a `kernel` function and imports a shared
-`memory`. When invoked by `parallel-for`, this kernel is instantiated by the
+`memory`. When invoked by `parallel-exec`, this kernel is instantiated by the
 host and scheduled on the parallel device; the call returns once the parallel
 execution is complete.
 
 ```wit
-parallel-for: func(device: device, kernel: list<u8>, num-iterations: u32, block-size: u32, buffers: list<buffer>) -> expected<unit, error>
+parallel-exec: func(device: device, kernel: list<u8>, num-iterations: u32, block-size: u32, buffers: list<buffer>) -> expected<unit, error>
 ```
 
 

--- a/wasi-parallel.witx
+++ b/wasi-parallel.witx
@@ -98,7 +98,7 @@
   )
 
   ;;; Run a function in parallel--a "parallel for" mechanism.
-  (@interface func (export "parallel_for")
+  (@interface func (export "parallel_exec")
     ;;; The code to run in parallel.
     (param $worker $function)
     ;;; The total number of times to run the $worker function.


### PR DESCRIPTION
@mingqiusun, here is the API name change from #7.