### PR TITLE
Add `device` parameter

### DIFF
--- a/wasi-parallel.witx
+++ b/wasi-parallel.witx
@@ -99,6 +99,8 @@
 
   ;;; Run a function in parallel--a "parallel for" mechanism.
   (@interface func (export "parallel_exec")
+    ;;; The device on which to run in parallel.
+    (param $device $parallel_device)
     ;;; The code to run in parallel.
     (param $worker $function)
     ;;; The total number of times to run the $worker function.


### PR DESCRIPTION
The API now would require a user to specify which device to run the kernel on. Previously, this was inferred from the input and output buffers, which is not entirely clear, especially when no buffers are passed.