### PR TITLE
Update link to WASI Proposals.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ API for parallel computation.
 
 `wasi-parallel` is currently in [Phase 1].
 
-[Phase 1]: https://github.com/WebAssembly/WASI/blob/main/Proposals.md#phase-1---feature-proposal-cg
+[Phase 1]: https://github.com/WebAssembly/WASI/blob/main/docs/Proposals.md#phase-1---feature-proposal-cg
 
 ### Champions
 


### PR DESCRIPTION
The location of the WASI Proposals.md file is being changed in https://github.com/WebAssembly/WASI/pull/831, this updates all the links in this repository to reflect that change. I'm initially filing this PR as a draft. I'll mark it as ready to review once the linked PR has been merged. Thanks!